### PR TITLE
change ipairs to pairs

### DIFF
--- a/lua/ltex_extra/src/commands-lsp.lua
+++ b/lua/ltex_extra/src/commands-lsp.lua
@@ -13,7 +13,7 @@ local function catch_ltex()
     log.trace("catch_ltex")
     local buf_clients = vim.lsp.buf_get_clients()
     local client = nil
-    for _, lsp in ipairs(buf_clients) do
+    for _, lsp in pairs(buf_clients) do
         if lsp.name == "ltex" then client = lsp end
     end
     return client


### PR DESCRIPTION
This is a fix for the issue I experienced that is described here:
https://github.com/neovim/neovim/issues/14618

In short, having multiple LSP servers running in separate windows causes the error "Error catching ltex client" when opening a markdown file.

Looking around, I found mention of replacing ipairs with pairs to fix this issue:
https://github.com/ray-x/navigator.lua/issues/167

This change solves the problem for me.