### PR TITLE
Error catching ltex client fix

### DIFF
--- a/lua/ltex_extra/src/commands-lsp.lua
+++ b/lua/ltex_extra/src/commands-lsp.lua
@@ -1,115 +1,128 @@
 local log = require("ltex_extra.src.log")
 
 local exportFile = require("ltex_extra.src.utils").exportFile
-local loadFile  = require("ltex_extra.src.utils").loadFile
+local loadFile = require("ltex_extra.src.utils").loadFile
 
 local types = {
-    ["dict"] = "dictionary",
-    ["dRules"] = "disabledRules",
-    ["hRules"] = "hiddenFalsePositives"
+	["dict"] = "dictionary",
+	["dRules"] = "disabledRules",
+	["hRules"] = "hiddenFalsePositives",
 }
 
 local function catch_ltex()
-    log.trace("catch_ltex")
-    local buf_clients = vim.lsp.buf_get_clients()
-    local client = nil
-    for _, lsp in pairs(buf_clients) do
-        if lsp.name == "ltex" then client = lsp end
-    end
-    return client
+	log.trace("catch_ltex")
+	local buf_clients
+	repeat
+		buf_clients = vim.lsp.buf_get_clients()
+	until #buf_clients > 0
+	local client = nil
+	for _, lsp in pairs(buf_clients) do
+		if lsp.name == "ltex" then
+			client = lsp
+		end
+	end
+	return client
 end
 
 local function update_dictionary(client, lang)
-    log.trace("update_dictionary")
-    if not client.config.settings.ltex.dictionary then
-        client.config.settings.ltex.dictionary = {}
-    end
-    client.config.settings.ltex.dictionary[lang] = loadFile(types.dict, lang)
-    log.debug(vim.inspect(client.config.settings.ltex.dictionary))
-    return client.notify('workspace/didChangeConfiguration', client.config.settings)
+	log.trace("update_dictionary")
+	if not client.config.settings.ltex.dictionary then
+		client.config.settings.ltex.dictionary = {}
+	end
+	client.config.settings.ltex.dictionary[lang] = loadFile(types.dict, lang)
+	log.debug(vim.inspect(client.config.settings.ltex.dictionary))
+	return client.notify("workspace/didChangeConfiguration", client.config.settings)
 end
 
 local function update_disabledRules(client, lang)
-    log.trace("update_disabledRules")
-    if not client.config.settings.ltex.disabledRules then
-        client.config.settings.ltex.disabledRules = {}
-    end
-    client.config.settings.ltex.disabledRules[lang] = loadFile(types.dRules, lang)
-    log.debug(vim.inspect(client.config.settings.ltex.disabledRules))
-    return client.notify('workspace/didChangeConfiguration', client.config.settings)
+	log.trace("update_disabledRules")
+	if not client.config.settings.ltex.disabledRules then
+		client.config.settings.ltex.disabledRules = {}
+	end
+	client.config.settings.ltex.disabledRules[lang] = loadFile(types.dRules, lang)
+	log.debug(vim.inspect(client.config.settings.ltex.disabledRules))
+	return client.notify("workspace/didChangeConfiguration", client.config.settings)
 end
 
 local function update_hiddenFalsePositive(client, lang)
-    log.trace("update_hiddenFalsePositive")
-    if not client.config.settings.ltex.hiddenFalsePositives then
-        client.config.settings.ltex.hiddenFalsePositives = {}
-    end
-    client.config.settings.ltex.hiddenFalsePositives[lang] = loadFile(types.hRules, lang)
-    log.debug(vim.inspect(client.config.settings.ltex.hiddenFalsePositives))
-    return client.notify('workspace/didChangeConfiguration', client.config.settings)
+	log.trace("update_hiddenFalsePositive")
+	if not client.config.settings.ltex.hiddenFalsePositives then
+		client.config.settings.ltex.hiddenFalsePositives = {}
+	end
+	client.config.settings.ltex.hiddenFalsePositives[lang] = loadFile(types.hRules, lang)
+	log.debug(vim.inspect(client.config.settings.ltex.hiddenFalsePositives))
+	return client.notify("workspace/didChangeConfiguration", client.config.settings)
 end
 
 local M = {}
 
 M.updateConfig = function(configtype, lang)
-    log.trace("updateConfig")
-    local client = catch_ltex()
-    if client then
-        if configtype == types.dict then
-            update_dictionary(client, lang)
-        elseif configtype == types.dRules then
-            update_disabledRules(client, lang)
-        elseif configtype == types.hRules then
-            update_hiddenFalsePositive(client, lang)
-        else
-            log.fmt_error("Config type unknown")
-            return vim.notify("Config type unknown")
-        end
-    else
-        log.fmt_error("Error catching ltex client")
-        return vim.notify("Error catching ltex client")
-    end
+	log.trace("updateConfig")
+	local client = catch_ltex()
+	if client then
+		if configtype == types.dict then
+			update_dictionary(client, lang)
+		elseif configtype == types.dRules then
+			update_disabledRules(client, lang)
+		elseif configtype == types.hRules then
+			update_hiddenFalsePositive(client, lang)
+		else
+			log.fmt_error("Config type unknown")
+			return vim.notify("Config type unknown")
+		end
+	else
+		log.fmt_error("Error catching ltex client")
+		return vim.notify("Error catching ltex client")
+	end
 end
 
 M.reload = function(langs)
-    log.trace("updateConfigFull")
-    langs = langs or package.loaded.ltex_extra.opts.load_langs
-    for _, lang in pairs(langs) do
-        log.fmt_trace("Loading %s", lang)
-        M.updateConfig(types.dict, lang)
-        M.updateConfig(types.dRules, lang)
-        M.updateConfig(types.hRules, lang)
-    end
+	log.trace("updateConfigFull")
+	langs = langs or package.loaded.ltex_extra.opts.load_langs
+	for _, lang in pairs(langs) do
+		log.fmt_trace("Loading %s", lang)
+		vim.schedule(function()
+			M.updateConfig(types.dict, lang)
+			M.updateConfig(types.dRules, lang)
+			M.updateConfig(types.hRules, lang)
+		end)
+	end
 end
 
 M.addToDictionary = function(command)
-    log.trace("addToDictionary")
-    local args = command.arguments[1].words
-    for lang, words in pairs(args) do
-        log.fmt_debug("Lang: %s Words: %s", vim.inspect(lang), vim.inspect(words))
-        exportFile(types.dict, lang, words)
-        M.updateConfig(types.dict, lang)
-    end
+	log.trace("addToDictionary")
+	local args = command.arguments[1].words
+	for lang, words in pairs(args) do
+		log.fmt_debug("Lang: %s Words: %s", vim.inspect(lang), vim.inspect(words))
+		exportFile(types.dict, lang, words)
+		vim.schedule(function()
+			M.updateConfig(types.dict, lang)
+		end)
+	end
 end
 
 M.disableRules = function(command)
-    log.trace("disableRules")
-    local args = command.arguments[1].ruleIds
-    for lang, rules in pairs(args) do
-        log.fmt_debug("Lang: %s Rules: %s", vim.inspect(lang), vim.inspect(rules))
-        exportFile(types.dRules, lang, rules)
-        M.updateConfig(types.dRules, lang)
-    end
+	log.trace("disableRules")
+	local args = command.arguments[1].ruleIds
+	for lang, rules in pairs(args) do
+		log.fmt_debug("Lang: %s Rules: %s", vim.inspect(lang), vim.inspect(rules))
+		exportFile(types.dRules, lang, rules)
+		vim.schedule(function()
+			M.updateConfig(types.dRules, lang)
+		end)
+	end
 end
 
 M.hideFalsePositives = function(command)
-    log.trace("hideFalsePositives")
-    local args = command.arguments[1].falsePositives
-    for lang, rules in pairs(args) do
-        log.fmt_debug("Lang: %s Rules: %s", vim.inspect(lang), vim.inspect(rules))
-        exportFile(types.hRules, lang, rules)
-        M.updateConfig(types.hRules, lang)
-    end
+	log.trace("hideFalsePositives")
+	local args = command.arguments[1].falsePositives
+	for lang, rules in pairs(args) do
+		log.fmt_debug("Lang: %s Rules: %s", vim.inspect(lang), vim.inspect(rules))
+		exportFile(types.hRules, lang, rules)
+		vim.schedule(function()
+			M.updateConfig(types.hRules, lang)
+		end)
+	end
 end
 
 return M

--- a/lua/ltex_extra/src/commands-lsp.lua
+++ b/lua/ltex_extra/src/commands-lsp.lua
@@ -1,4 +1,4 @@
-local log = require "ltex_extra.src.log"
+local log = require("ltex_extra.src.log")
 
 local exportFile = require("ltex_extra.src.utils").exportFile
 local loadFile = require("ltex_extra.src.utils").loadFile
@@ -10,11 +10,8 @@ local types = {
 }
 
 local function catch_ltex()
-    log.trace "catch_ltex"
-    local buf_clients
-    repeat
-        buf_clients = vim.lsp.buf_get_clients()
-    until #buf_clients > 0
+    log.trace("catch_ltex")
+    local buf_clients = vim.lsp.buf_get_clients()
     local client = nil
     for _, lsp in pairs(buf_clients) do
         if lsp.name == "ltex" then
@@ -25,7 +22,7 @@ local function catch_ltex()
 end
 
 local function update_dictionary(client, lang)
-    log.trace "update_dictionary"
+    log.trace("update_dictionary")
     if not client.config.settings.ltex.dictionary then
         client.config.settings.ltex.dictionary = {}
     end
@@ -35,7 +32,7 @@ local function update_dictionary(client, lang)
 end
 
 local function update_disabledRules(client, lang)
-    log.trace "update_disabledRules"
+    log.trace("update_disabledRules")
     if not client.config.settings.ltex.disabledRules then
         client.config.settings.ltex.disabledRules = {}
     end
@@ -45,7 +42,7 @@ local function update_disabledRules(client, lang)
 end
 
 local function update_hiddenFalsePositive(client, lang)
-    log.trace "update_hiddenFalsePositive"
+    log.trace("update_hiddenFalsePositive")
     if not client.config.settings.ltex.hiddenFalsePositives then
         client.config.settings.ltex.hiddenFalsePositives = {}
     end
@@ -57,7 +54,7 @@ end
 local M = {}
 
 M.updateConfig = function(configtype, lang)
-    log.trace "updateConfig"
+    log.trace("updateConfig")
     local client = catch_ltex()
     if client then
         if configtype == types.dict then
@@ -67,17 +64,17 @@ M.updateConfig = function(configtype, lang)
         elseif configtype == types.hRules then
             update_hiddenFalsePositive(client, lang)
         else
-            log.fmt_error "Config type unknown"
-            return vim.notify "Config type unknown"
+            log.fmt_error("Config type unknown")
+            return vim.notify("Config type unknown")
         end
     else
-        log.fmt_error "Error catching ltex client"
-        return vim.notify "Error catching ltex client"
+        log.fmt_error("Error catching ltex client")
+        return vim.notify("Error catching ltex client")
     end
 end
 
 M.reload = function(langs)
-    log.trace "updateConfigFull"
+    log.trace("updateConfigFull")
     langs = langs or package.loaded.ltex_extra.opts.load_langs
     for _, lang in pairs(langs) do
         log.fmt_trace("Loading %s", lang)
@@ -90,7 +87,7 @@ M.reload = function(langs)
 end
 
 M.addToDictionary = function(command)
-    log.trace "addToDictionary"
+    log.trace("addToDictionary")
     local args = command.arguments[1].words
     for lang, words in pairs(args) do
         log.fmt_debug("Lang: %s Words: %s", vim.inspect(lang), vim.inspect(words))
@@ -102,7 +99,7 @@ M.addToDictionary = function(command)
 end
 
 M.disableRules = function(command)
-    log.trace "disableRules"
+    log.trace("disableRules")
     local args = command.arguments[1].ruleIds
     for lang, rules in pairs(args) do
         log.fmt_debug("Lang: %s Rules: %s", vim.inspect(lang), vim.inspect(rules))
@@ -114,7 +111,7 @@ M.disableRules = function(command)
 end
 
 M.hideFalsePositives = function(command)
-    log.trace "hideFalsePositives"
+    log.trace("hideFalsePositives")
     local args = command.arguments[1].falsePositives
     for lang, rules in pairs(args) do
         log.fmt_debug("Lang: %s Rules: %s", vim.inspect(lang), vim.inspect(rules))

--- a/lua/ltex_extra/src/commands-lsp.lua
+++ b/lua/ltex_extra/src/commands-lsp.lua
@@ -1,128 +1,128 @@
-local log = require("ltex_extra.src.log")
+local log = require "ltex_extra.src.log"
 
 local exportFile = require("ltex_extra.src.utils").exportFile
 local loadFile = require("ltex_extra.src.utils").loadFile
 
 local types = {
-	["dict"] = "dictionary",
-	["dRules"] = "disabledRules",
-	["hRules"] = "hiddenFalsePositives",
+    ["dict"] = "dictionary",
+    ["dRules"] = "disabledRules",
+    ["hRules"] = "hiddenFalsePositives",
 }
 
 local function catch_ltex()
-	log.trace("catch_ltex")
-	local buf_clients
-	repeat
-		buf_clients = vim.lsp.buf_get_clients()
-	until #buf_clients > 0
-	local client = nil
-	for _, lsp in pairs(buf_clients) do
-		if lsp.name == "ltex" then
-			client = lsp
-		end
-	end
-	return client
+    log.trace "catch_ltex"
+    local buf_clients
+    repeat
+        buf_clients = vim.lsp.buf_get_clients()
+    until #buf_clients > 0
+    local client = nil
+    for _, lsp in pairs(buf_clients) do
+        if lsp.name == "ltex" then
+            client = lsp
+        end
+    end
+    return client
 end
 
 local function update_dictionary(client, lang)
-	log.trace("update_dictionary")
-	if not client.config.settings.ltex.dictionary then
-		client.config.settings.ltex.dictionary = {}
-	end
-	client.config.settings.ltex.dictionary[lang] = loadFile(types.dict, lang)
-	log.debug(vim.inspect(client.config.settings.ltex.dictionary))
-	return client.notify("workspace/didChangeConfiguration", client.config.settings)
+    log.trace "update_dictionary"
+    if not client.config.settings.ltex.dictionary then
+        client.config.settings.ltex.dictionary = {}
+    end
+    client.config.settings.ltex.dictionary[lang] = loadFile(types.dict, lang)
+    log.debug(vim.inspect(client.config.settings.ltex.dictionary))
+    return client.notify("workspace/didChangeConfiguration", client.config.settings)
 end
 
 local function update_disabledRules(client, lang)
-	log.trace("update_disabledRules")
-	if not client.config.settings.ltex.disabledRules then
-		client.config.settings.ltex.disabledRules = {}
-	end
-	client.config.settings.ltex.disabledRules[lang] = loadFile(types.dRules, lang)
-	log.debug(vim.inspect(client.config.settings.ltex.disabledRules))
-	return client.notify("workspace/didChangeConfiguration", client.config.settings)
+    log.trace "update_disabledRules"
+    if not client.config.settings.ltex.disabledRules then
+        client.config.settings.ltex.disabledRules = {}
+    end
+    client.config.settings.ltex.disabledRules[lang] = loadFile(types.dRules, lang)
+    log.debug(vim.inspect(client.config.settings.ltex.disabledRules))
+    return client.notify("workspace/didChangeConfiguration", client.config.settings)
 end
 
 local function update_hiddenFalsePositive(client, lang)
-	log.trace("update_hiddenFalsePositive")
-	if not client.config.settings.ltex.hiddenFalsePositives then
-		client.config.settings.ltex.hiddenFalsePositives = {}
-	end
-	client.config.settings.ltex.hiddenFalsePositives[lang] = loadFile(types.hRules, lang)
-	log.debug(vim.inspect(client.config.settings.ltex.hiddenFalsePositives))
-	return client.notify("workspace/didChangeConfiguration", client.config.settings)
+    log.trace "update_hiddenFalsePositive"
+    if not client.config.settings.ltex.hiddenFalsePositives then
+        client.config.settings.ltex.hiddenFalsePositives = {}
+    end
+    client.config.settings.ltex.hiddenFalsePositives[lang] = loadFile(types.hRules, lang)
+    log.debug(vim.inspect(client.config.settings.ltex.hiddenFalsePositives))
+    return client.notify("workspace/didChangeConfiguration", client.config.settings)
 end
 
 local M = {}
 
 M.updateConfig = function(configtype, lang)
-	log.trace("updateConfig")
-	local client = catch_ltex()
-	if client then
-		if configtype == types.dict then
-			update_dictionary(client, lang)
-		elseif configtype == types.dRules then
-			update_disabledRules(client, lang)
-		elseif configtype == types.hRules then
-			update_hiddenFalsePositive(client, lang)
-		else
-			log.fmt_error("Config type unknown")
-			return vim.notify("Config type unknown")
-		end
-	else
-		log.fmt_error("Error catching ltex client")
-		return vim.notify("Error catching ltex client")
-	end
+    log.trace "updateConfig"
+    local client = catch_ltex()
+    if client then
+        if configtype == types.dict then
+            update_dictionary(client, lang)
+        elseif configtype == types.dRules then
+            update_disabledRules(client, lang)
+        elseif configtype == types.hRules then
+            update_hiddenFalsePositive(client, lang)
+        else
+            log.fmt_error "Config type unknown"
+            return vim.notify "Config type unknown"
+        end
+    else
+        log.fmt_error "Error catching ltex client"
+        return vim.notify "Error catching ltex client"
+    end
 end
 
 M.reload = function(langs)
-	log.trace("updateConfigFull")
-	langs = langs or package.loaded.ltex_extra.opts.load_langs
-	for _, lang in pairs(langs) do
-		log.fmt_trace("Loading %s", lang)
-		vim.schedule(function()
-			M.updateConfig(types.dict, lang)
-			M.updateConfig(types.dRules, lang)
-			M.updateConfig(types.hRules, lang)
-		end)
-	end
+    log.trace "updateConfigFull"
+    langs = langs or package.loaded.ltex_extra.opts.load_langs
+    for _, lang in pairs(langs) do
+        log.fmt_trace("Loading %s", lang)
+        vim.schedule(function()
+            M.updateConfig(types.dict, lang)
+            M.updateConfig(types.dRules, lang)
+            M.updateConfig(types.hRules, lang)
+        end)
+    end
 end
 
 M.addToDictionary = function(command)
-	log.trace("addToDictionary")
-	local args = command.arguments[1].words
-	for lang, words in pairs(args) do
-		log.fmt_debug("Lang: %s Words: %s", vim.inspect(lang), vim.inspect(words))
-		exportFile(types.dict, lang, words)
-		vim.schedule(function()
-			M.updateConfig(types.dict, lang)
-		end)
-	end
+    log.trace "addToDictionary"
+    local args = command.arguments[1].words
+    for lang, words in pairs(args) do
+        log.fmt_debug("Lang: %s Words: %s", vim.inspect(lang), vim.inspect(words))
+        exportFile(types.dict, lang, words)
+        vim.schedule(function()
+            M.updateConfig(types.dict, lang)
+        end)
+    end
 end
 
 M.disableRules = function(command)
-	log.trace("disableRules")
-	local args = command.arguments[1].ruleIds
-	for lang, rules in pairs(args) do
-		log.fmt_debug("Lang: %s Rules: %s", vim.inspect(lang), vim.inspect(rules))
-		exportFile(types.dRules, lang, rules)
-		vim.schedule(function()
-			M.updateConfig(types.dRules, lang)
-		end)
-	end
+    log.trace "disableRules"
+    local args = command.arguments[1].ruleIds
+    for lang, rules in pairs(args) do
+        log.fmt_debug("Lang: %s Rules: %s", vim.inspect(lang), vim.inspect(rules))
+        exportFile(types.dRules, lang, rules)
+        vim.schedule(function()
+            M.updateConfig(types.dRules, lang)
+        end)
+    end
 end
 
 M.hideFalsePositives = function(command)
-	log.trace("hideFalsePositives")
-	local args = command.arguments[1].falsePositives
-	for lang, rules in pairs(args) do
-		log.fmt_debug("Lang: %s Rules: %s", vim.inspect(lang), vim.inspect(rules))
-		exportFile(types.hRules, lang, rules)
-		vim.schedule(function()
-			M.updateConfig(types.hRules, lang)
-		end)
-	end
+    log.trace "hideFalsePositives"
+    local args = command.arguments[1].falsePositives
+    for lang, rules in pairs(args) do
+        log.fmt_debug("Lang: %s Rules: %s", vim.inspect(lang), vim.inspect(rules))
+        exportFile(types.hRules, lang, rules)
+        vim.schedule(function()
+            M.updateConfig(types.hRules, lang)
+        end)
+    end
 end
 
 return M


### PR DESCRIPTION
This PR should close #23.

Essentially, it wraps all calls of `updateConfig` with `vim.schedule`. Thus they will be called within the main event loop and `vim.lsp.buf_get_clients()` returns the correct attached LSPs.
