### PR TITLE
feat(config): ltex_extra sets lspconfig for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,27 +76,38 @@ use { "barreiroleo/ltex-extra.nvim" }
 ```
 
 ## Configuration
-The recommended way to use `ltex-extra` is calling it from `ltex-ls` `on_attach` event.
-Next example use `nvim-config` typical launch server and default settings for `ltex-extra`, you can use it as template.
+Install the plugin with your favorite plugin manager, then add `require("ltex_extra").setup()` to your config.
+The plugin will set up the `ltex` language server for you (by calling the setup function of the server from `lspconfig` internally).
+So **you don't manually `require("lspconfig").ltex.setup`, as it can cause conflicts**.
+
+The configuration of the underlying `require("lspconfig").ltex.setup(...)` call is passed under the `server` key.
+Below is an example configuration; default config values are in the comments.
 
 *Notes: You can pass to set up only the arguments that you are interested in.
 At the moment, if you define stuff in `dictionary`, `disabledRules` and `hiddenFalsePositives` in your `ltex` settings, they haven't backup.*
 
 ```lua
-require("lspconfig").ltex.setup {
-    capabilities = your_capabilities,
-    on_attach = function(client, bufnr)
-        -- your other on_attach functions.
-        require("ltex_extra").setup{
-            load_langs = { "es-AR", "en-US" }, -- table <string> : languages for witch dictionaries will be loaded
-            init_check = true, -- boolean : whether to load dictionaries on startup
-            path = nil, -- string : path to store dictionaries. Relative path uses current working directory
-            log_level = "none", -- string : "none", "trace", "debug", "info", "warn", "error", "fatal"
-        }
-    end,
-    settings = {
+require("ltex_extra").setup{
+    -- table <string> : languages for witch dictionaries will be loaded
+    -- Default : {}
+    load_langs = { "es-AR", "en-US" },
+    -- boolean : whether to load dictionaries on startup
+    -- default : true
+    init_check = true,
+    -- string : path to store dictionaries. Relative path are based off the current working directory
+    -- Default : nil = the current working directory
+    path = "~/.config/ltex",
+    -- string : "none", "trace", "debug", "info", "warn", "error", "fatal"
+    -- Default : "none"
+    log_level = "none",
+    -- table : configurations of the ltex language server
+    server = {
+        capabilities = your_capabilities,
+        on_attach = function(client, bufnr)
+            -- Your on_attach
+        end,
         ltex = {
-            -- your settings.
+            -- your server settings
         }
     }
 }

--- a/lua/ltex_extra/init.lua
+++ b/lua/ltex_extra/init.lua
@@ -1,32 +1,68 @@
-local M = {}
-
 local default_opts = {
     load_langs = {}, -- table <string> : language for witch dictionaries will be loaded
     init_check = true, -- boolean : whether to load dictionaries on startup
     path = nil, -- string : path to store dictionaries. Relative path uses current working directory
     log_level = "none", -- string : "none", "trace", "debug", "info", "warn", "error", "fatal"
+    server = {},
 }
+
+local M = {}
 
 M.opts = {}
 
-M.reload = function(...) require("ltex_extra.src.commands-lsp").reload(...) end
+M.reload = function(...)
+    require("ltex_extra.src.commands-lsp").reload(...)
+end
 
 M.setup = function(opts)
-    if opts.path then opts.path = vim.fs.normalize(opts.path .. "/") else opts.path = "" end
-    M.opts = vim.tbl_deep_extend('force', default_opts, opts)
-
     local log = require("ltex_extra.src.log")
+
+    if opts.path then
+        opts.path = vim.fs.normalize(opts.path .. "/")
+    else
+        opts.path = ""
+    end
+
+    if not opts.server then
+        opts.server = {}
+    end
+    local on_attach = opts.server.on_attach
+    opts.server.on_attach = function(...)
+        log.trace("Add commands to lsp")
+        vim.lsp.commands["_ltex.addToDictionary"] = require("ltex_extra.src.commands-lsp").addToDictionary
+        vim.lsp.commands["_ltex.hideFalsePositives"] = require("ltex_extra.src.commands-lsp").hideFalsePositives
+        vim.lsp.commands["_ltex.disableRules"] = require("ltex_extra.src.commands-lsp").disableRules
+        if on_attach then
+            on_attach(...)
+        end
+        log.trace("Inital load files")
+        if M.opts.init_check == true then
+            M.reload(M.opts.load_langs)
+        end
+    end
+
+    M.opts = vim.tbl_deep_extend("force", default_opts, opts)
     log.debug("Opts: " .. vim.inspect(M.opts))
 
-    log.trace("Add commands to lsp")
-    vim.lsp.commands['_ltex.addToDictionary']    = require("ltex_extra.src.commands-lsp").addToDictionary
-    vim.lsp.commands['_ltex.hideFalsePositives'] = require("ltex_extra.src.commands-lsp").hideFalsePositives
-    vim.lsp.commands['_ltex.disableRules']       = require("ltex_extra.src.commands-lsp").disableRules
-
-    log.trace("Inital load files")
-    if M.opts.init_check == true then
-        M.reload(M.opts.load_langs)
+    if require("ltex_extra.src.commands-lsp").catch_ltex() then
+        vim.notify(
+            [[Newer version of LTeX_extra will set up lspconfig for you.
+The old pattern of setting up in on_attach is deprecated.
+Please remove any manual setup of ltex server.]],
+            vim.log.levels.WARN
+        )
+        opts.server.on_attach()
+        return
     end
+
+    local ok, lspconfig = pcall(require, "lspconfig")
+    if not ok then
+        vim.notify("LTeX_extra setup terminates because lspconfig module is not found", vim.log.levels.ERROR)
+        return
+    end
+
+    log.trace("Setup lspconfig")
+    lspconfig["ltex"].setup(opts.server)
 end
 
 return M

--- a/lua/ltex_extra/init.lua
+++ b/lua/ltex_extra/init.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 local default_opts = {
-    load_langs = { "es-AR", "en-US" }, -- table <string> : language for witch dictionaries will be loaded
+    load_langs = {}, -- table <string> : language for witch dictionaries will be loaded
     init_check = true, -- boolean : whether to load dictionaries on startup
     path = nil, -- string : path to store dictionaries. Relative path uses current working directory
     log_level = "none", -- string : "none", "trace", "debug", "info", "warn", "error", "fatal"

--- a/lua/ltex_extra/src/commands-lsp.lua
+++ b/lua/ltex_extra/src/commands-lsp.lua
@@ -1,22 +1,13 @@
 local log = require("ltex_extra.src.log")
 
 local exportFile = require("ltex_extra.src.utils").exportFile
-local loadFile   = require("ltex_extra.src.utils").loadFile
+local loadFile = require("ltex_extra.src.utils").loadFile
 
 local types = {
     ["dict"] = "dictionary",
     ["dRules"] = "disabledRules",
-    ["hRules"] = "hiddenFalsePositives"
+    ["hRules"] = "hiddenFalsePositives",
 }
-
-local function catch_ltex()
-    log.trace("catch_ltex")
-    local buf_clients = vim.lsp.get_active_clients({
-        bufnr = vim.api.nvim_get_current_buf(),
-        name = "ltex",
-    })
-    return buf_clients[1]
-end
 
 local function get_settings(client)
     if not client.config.settings.ltex then
@@ -35,7 +26,7 @@ local function update_dictionary(client, lang)
     local settings = get_settings(client)
     settings.ltex.dictionary[lang] = loadFile(types.dict, lang)
     log.debug(vim.inspect(settings.ltex.dictionary))
-    return client.notify('workspace/didChangeConfiguration', settings)
+    return client.notify("workspace/didChangeConfiguration", settings)
 end
 
 local function update_disabledRules(client, lang)
@@ -43,7 +34,7 @@ local function update_disabledRules(client, lang)
     local settings = get_settings(client)
     settings.ltex.disabledRules[lang] = loadFile(types.dRules, lang)
     log.debug(vim.inspect(settings.ltex.disabledRules))
-    return client.notify('workspace/didChangeConfiguration', settings)
+    return client.notify("workspace/didChangeConfiguration", settings)
 end
 
 local function update_hiddenFalsePositive(client, lang)
@@ -51,14 +42,23 @@ local function update_hiddenFalsePositive(client, lang)
     local settings = get_settings(client)
     settings.ltex.hiddenFalsePositives[lang] = loadFile(types.hRules, lang)
     log.debug(vim.inspect(settings.ltex.hiddenFalsePositives))
-    return client.notify('workspace/didChangeConfiguration', settings)
+    return client.notify("workspace/didChangeConfiguration", settings)
 end
 
 local M = {}
 
+M.catch_ltex = function()
+    log.trace("catch_ltex")
+    local buf_clients = vim.lsp.get_active_clients({
+        bufnr = vim.api.nvim_get_current_buf(),
+        name = "ltex",
+    })
+    return buf_clients[1]
+end
+
 M.updateConfig = function(configtype, lang)
     log.trace("updateConfig")
-    local client = catch_ltex()
+    local client = M.catch_ltex()
     if client then
         if configtype == types.dict then
             update_dictionary(client, lang)

--- a/lua/ltex_extra/src/commands-lsp.lua
+++ b/lua/ltex_extra/src/commands-lsp.lua
@@ -11,12 +11,11 @@ local types = {
 
 local function catch_ltex()
     log.trace("catch_ltex")
-    local buf_clients = vim.lsp.buf_get_clients()
-    local client = nil
-    for _, lsp in pairs(buf_clients) do
-        if lsp.name == "ltex" then client = lsp end
-    end
-    return client
+    local buf_clients = vim.lsp.get_active_clients({
+        bufnr = vim.api.nvim_get_current_buf(),
+        name = "ltex",
+    })
+    return buf_clients[1]
 end
 
 local function get_settings(client)

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,2 @@
+indent_type = "Spaces"
+indent_width = 4


### PR DESCRIPTION
The new setup method is documented in the README file.
Also, this PR removes default load_langs (en and es) which may not get rid of when merging options. This PR also replaces deprecated lsp API.