### PR TITLE
fix: incorrect way of appending filename to path

### DIFF
--- a/lua/ltex_extra/src/utils.lua
+++ b/lua/ltex_extra/src/utils.lua
@@ -5,7 +5,7 @@ local M = {}
 
 -- Returns the filename for a type and lang required.
 M.joinPath = function(type, lang)
-    return path .. table.concat({ "ltex", type, lang, "txt" }, ".")
+    return vim.fs.normalize(path .. "/" .. table.concat({ "ltex", type, lang, "txt" }, "."))
 end
 
 -- Check if path exist. Apply for files and dirs.


### PR DESCRIPTION
This fixes the problem for the location where the dictionaries are saved. Previously, in the config phase, the `path` in the `joinPath` function [defined here](https://github.com/barreiroleo/ltex_extra.nvim/blob/1d2f288ceedc70d5a9c00f55c0d0cc788b5164f2/lua/ltex_extra/src/utils.lua#L8) is normalized (which means, it does not have trailing `/` at its end). Then, when concatenating the filename it results in a wrong filename.

Example:
```lua
require("ltex_extra").setup {
  path = vim.fn.stdpath "config" .. "/dicts",
  ...
}
```
This results in creating a file `dictsltex.dictionary.en_US.txt` in `$XDG_CONFIG_HOME`, instead of `dicts/ltex.dictionary.en_US.txt`.