### PR TITLE
fix: file saving when config path value is empty

### DIFF
--- a/lua/ltex_extra/init.lua
+++ b/lua/ltex_extra/init.lua
@@ -46,7 +46,7 @@ end
 
 M.setup = function(opts)
     M.opts = vim.tbl_deep_extend("force", M.opts, opts or {})
-    M.opts.path = vim.fs.normalize(M.opts.path) .. "/"
+    M.opts.path = vim.fs.normalize(M.opts.path)
 
     register_lsp_commands()
 

--- a/lua/ltex_extra/utils/fs.lua
+++ b/lua/ltex_extra/utils/fs.lua
@@ -1,5 +1,6 @@
 local log = require("ltex_extra.utils.log")
 local config_path = package.loaded.ltex_extra.opts.path
+local uv = vim.loop
 
 local M = {}
 
@@ -10,7 +11,7 @@ M.path = function()
         return config_path .. "/"
     else
         -- Assume relative path so append to the cwd
-        return vim.fs.normalize(vim.loop.cwd() .. "/" .. config_path) .. "/"
+        return vim.fs.normalize(uv.cwd() .. "/" .. config_path) .. "/"
     end
 end
 
@@ -22,14 +23,13 @@ end
 -- Check if path exist. Apply for files and dirs.
 M.path_exist = function(path)
     log.trace("Checking path ", path)
-    return vim.loop.fs_stat(path) ~= nil
+    return uv.fs_stat(path) ~= nil
 end
 
 -- Make a specified directory and check if created succesfully.
 M.mkdir = function(dirname)
     log.trace("Making dir ", dirname)
-    local perm = tonumber("744", 8)
-    local ok, err = vim.loop.fs_mkdir(dirname, perm)
+    local ok, err = uv.fs_mkdir(dirname, 484)
     if not ok then
         log.vimwarn("Failed making directory: ", err)
         return false
@@ -42,7 +42,7 @@ end
 -- Check if a dir exist, if not, try to making it.
 M.check_dir = function(dirname)
     log.trace("Checking dir", dirname)
-    local stat = vim.loop.fs_stat(dirname)
+    local stat = uv.fs_stat(dirname)
     if not stat then
         log.info(dirname .. " not found, making it")
         if M.mkdir(dirname) then
@@ -60,13 +60,13 @@ end
 -- Write specified content into a file.
 M.writeFile = function(filename, lines)
     log.trace("Writing ", filename, lines)
-    local fd, err = vim.loop.fs_open(filename, "a+", 420)
+    local fd, err = uv.fs_open(filename, "a+", 420)
     if not fd then
         log.vimerror("Failed to open file " .. filename .. ": " .. err)
         return
     end
-    vim.loop.fs_write(fd, table.concat(lines, "\n") .. "\n")
-    vim.loop.fs_close(fd)
+    uv.fs_write(fd, table.concat(lines, "\n") .. "\n")
+    uv.fs_close(fd)
 end
 
 -- Export ltex data depends on the type and lang especified.
@@ -80,20 +80,41 @@ M.exportFile = function(type, lang, lines)
     end
 end
 
+-- Check if a file uses carriage returns in line feeds and, if so, remove them.
+M.check_line_feeds = function(filename, data)
+    log.trace("Checking if file uses carriage returns in line feeds")
+    local first_line = data:match(".*[^\n]")
+    if first_line and first_line:find("\r") then
+        log.debug("Found windows line feeds, replacing file contents")
+        data = data:gsub("\r\n", "\n")
+
+        -- Overwrite file with sanitized data
+        local fd, err = uv.fs_open(filename, "w", 420)
+        if not fd then
+            log.vimerror("Failed to open file " .. filename .. ": " .. err)
+            return data
+        end
+        uv.fs_write(fd, data)
+        uv.fs_close(fd)
+    end
+    return data
+end
+
 -- Return the content of a required file
 M.readFile = function(filename)
     log.trace("Reading ", filename)
-    local fd, err = vim.loop.fs_open(filename, "r", 420)
+    local fd, err = uv.fs_open(filename, "r", 420)
     if not fd then
         log.vimerror("Failed to open file " .. filename .. ": " .. err)
         return {}
     end
-    local stat = vim.loop.fs_fstat(fd)
+    local stat = uv.fs_fstat(fd)
     if not stat then
         return {}
     end
-    local data = vim.loop.fs_read(fd, stat.size)
-    vim.loop.fs_close(fd)
+    local data = uv.fs_read(fd, stat.size)
+    uv.fs_close(fd)
+    data = M.check_line_feeds(filename, data)
     return data and vim.split(data, "\n", { trimempty = true }) or {}
 end
 

--- a/lua/ltex_extra/utils/fs.lua
+++ b/lua/ltex_extra/utils/fs.lua
@@ -1,11 +1,22 @@
-local log  = require("ltex_extra.utils.log")
-local path = package.loaded.ltex_extra.opts.path
+local log = require("ltex_extra.utils.log")
+local config_path = package.loaded.ltex_extra.opts.path
 
 local M = {}
 
+-- Returns path to the directory where ltex files should be located.
+M.path = function()
+    -- Check if the absolute path the user has provided is valid
+    if config_path ~= "" and M.path_exist(config_path) then
+        return config_path .. "/"
+    else
+        -- Assume relative path so append to the cwd
+        return vim.fs.normalize(vim.loop.cwd() .. "/" .. config_path) .. "/"
+    end
+end
+
 -- Returns the filename for a type and lang required.
 M.joinPath = function(type, lang)
-    return vim.fs.normalize(path .. table.concat({ "ltex", type, lang, "txt" }, "."))
+    return vim.fs.normalize(M.path() .. table.concat({ "ltex", type, lang, "txt" }, "."))
 end
 
 -- Check if path exist. Apply for files and dirs.

--- a/lua/ltex_extra/utils/fs.lua
+++ b/lua/ltex_extra/utils/fs.lua
@@ -22,56 +22,58 @@ end
 -- Check if path exist. Apply for files and dirs.
 M.path_exist = function(path)
     log.trace("Checking path ", path)
-    local isok, errstr, errcode = os.rename(path, path)
-    if isok == nil then
-        log.warn(errstr, errcode)
-        return false
-    end
-    return true
+    return vim.loop.fs_stat(path) ~= nil
 end
 
--- Making a especified directory and check if created succesfully.
+-- Make a specified directory and check if created succesfully.
 M.mkdir = function(dirname)
     log.trace("Making dir ", dirname)
-    os.execute("mkdir " .. dirname)
-    if M.path_exist(dirname) then
-        log.info("Directory making succesfully ", dirname)
-        return true
-    else
-        log.vimwarn("Fail making directory")
+    local perm = tonumber("744", 8)
+    local ok, err = vim.loop.fs_mkdir(dirname, perm)
+    if not ok then
+        log.vimwarn("Failed making directory: ", err)
         return false
+    else
+        log.info("Directory made succesfully ", dirname)
+        return true
     end
 end
 
 -- Check if a dir exist, if not, try to making it.
 M.check_dir = function(dirname)
     log.trace("Checking dir", dirname)
-    if dirname == "" then return true end
-    if not M.path_exist(dirname) then
+    local stat = vim.loop.fs_stat(dirname)
+    if not stat then
         log.info(dirname .. " not found, making it")
-        if M.mkdir(dirname) then return true
-        else return false end
-    else
-        return true
+        if M.mkdir(dirname) then
+            return true
+        end
     end
+    ---@diagnostic disable-next-line: need-check-nil
+    if stat.type ~= "directory" then
+        log.vimwarn(dirname .. " is not a directory")
+        return false
+    end
+    return true
 end
 
--- Write especified content into a file.
+-- Write specified content into a file.
 M.writeFile = function(filename, lines)
-    log.trace("Writing ", filename)
-    local file = io.open(filename, "a+")
-    io.output(file)
-    for _, line in ipairs(lines) do
-        io.write(line .. "\n")
+    log.trace("Writing ", filename, lines)
+    local fd, err = vim.loop.fs_open(filename, "a+", 420)
+    if not fd then
+        log.vimerror("Failed to open file " .. filename .. ": " .. err)
+        return
     end
-    io.close(file)
+    vim.loop.fs_write(fd, table.concat(lines, "\n") .. "\n")
+    vim.loop.fs_close(fd)
 end
 
 -- Export ltex data depends on the type and lang especified.
 M.exportFile = function(type, lang, lines)
     log.trace("Exporting ", type, lang, lines)
     local filename = M.joinPath(type, lang)
-    if M.check_dir(path) then
+    if M.check_dir(M.path()) then
         M.writeFile(filename, lines)
     else
         log.vimwarn("Fail export " .. filename)
@@ -81,13 +83,18 @@ end
 -- Return the content of a required file
 M.readFile = function(filename)
     log.trace("Reading ", filename)
-    local lines, file = {}, io.open(filename, "r")
-    io.input(file)
-    for line in io.lines(filename) do
-        lines[#lines + 1] = line
+    local fd, err = vim.loop.fs_open(filename, "r", 420)
+    if not fd then
+        log.vimerror("Failed to open file " .. filename .. ": " .. err)
+        return {}
     end
-    io.close(file)
-    return lines
+    local stat = vim.loop.fs_fstat(fd)
+    if not stat then
+        return {}
+    end
+    local data = vim.loop.fs_read(fd, stat.size)
+    vim.loop.fs_close(fd)
+    return data and vim.split(data, "\n", { trimempty = true }) or {}
 end
 
 -- Return the content of a required type and lang.


### PR DESCRIPTION
This fixes a problem where setting `path = ""` would cause a "Fail making directory" error. I think it was due to the `fs.path_exist` function, but I've rewritten all of the file operation functions to use the seemingly more robust libuv library (it's also what most other plugins use).

I've also added functionality for detecting ltex files contain carriage returns and removing them if necessary. I ran into this problem on Windows where manually editing the ltex files added carriage returns, in turn breaking dictionary loading.