### PR TITLE
feat: file system watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ At the moment, if you define stuff in `dictionary`, `disabledRules` and
 
 ```lua
 require("ltex_extra").setup {
-    -- table <string> : languages for witch dictionaries will be loaded, e.g. { "es-AR", "en-US" }
+    -- table <string> : languages for which dictionaries will be loaded, e.g. { "es-AR", "en-US" }
     -- https://valentjn.github.io/ltex/supported-languages.html#natural-languages
     load_langs = {}, -- en-US as default
     -- boolean : whether to load dictionaries on startup
@@ -126,6 +126,11 @@ require("ltex_extra").setup {
     -- e.g. subfolder in current working directory: ".ltex"
     -- e.g. shared files for all projects :  vim.fn.expand("~") .. "/.local/share/ltex"
     path = "", -- current working directory
+    -- boolean : whether or not to enable the file watcher
+    -- watches ltex files and automatically refreshes the server if they are manually modified
+    -- WARNING only enable this option if your set path is exclusively for ltex files
+    -- otherwise the file watcher will refresh for changes made to irrelevant files
+    file_watcher = false,
     -- string : "none", "trace", "debug", "info", "warn", "error", "fatal"
     log_level = "none",
     -- table : configurations of the ltex language server.

--- a/lua/ltex_extra/commands-lsp.lua
+++ b/lua/ltex_extra/commands-lsp.lua
@@ -50,14 +50,13 @@ local M = {}
 function M.catch_ltex()
     log.trace("catch_ltex")
     local buf_clients = vim.lsp.get_active_clients({
-        bufnr = vim.api.nvim_get_current_buf(),
         name = "ltex",
     })
     return buf_clients[1]
 end
 
 function M.updateConfig(configtype, lang)
-    log.trace("updateConfig")
+    log.trace("updateConfig", configtype, lang)
     local client = M.catch_ltex()
     if client then
         if configtype == types.dict then
@@ -71,7 +70,7 @@ function M.updateConfig(configtype, lang)
             return vim.notify("Config type unknown")
         end
     else
-        return error("Error catching ltex client",1)
+        return error("Error catching ltex client", 1)
     end
 end
 

--- a/lua/ltex_extra/init.lua
+++ b/lua/ltex_extra/init.lua
@@ -27,7 +27,9 @@ end
 local function first_load()
     local fs = require("ltex_extra.utils.fs")
     fs.set_path()
-    fs.init_watcher()
+    if M.opts.file_watcher then
+        fs.init_watcher()
+    end
     if M.opts.init_check == true then
         M.reload(M.opts.load_langs)
     end

--- a/lua/ltex_extra/init.lua
+++ b/lua/ltex_extra/init.lua
@@ -1,11 +1,12 @@
 local M = {}
 
 M.opts = {
-    init_check = true,   -- boolean : whether to load dictionaries on startup
-    load_langs = {},     -- table <string> : language for witch dictionaries will be loaded
-    log_level = "none",  -- string : "none", "trace", "debug", "info", "warn", "error", "fatal"
-    path = "",           -- string : path to store dictionaries. Relative path uses current working directory
-    server_start = true, -- boolean : Enable the call to ltex. Usefull for migration and test
+    init_check = true,    -- boolean : whether to load dictionaries on startup
+    load_langs = {},      -- table <string> : language for witch dictionaries will be loaded
+    log_level = "none",   -- string : "none", "trace", "debug", "info", "warn", "error", "fatal"
+    path = "",            -- string : path to store dictionaries
+    file_watcher = false, -- boolean : whether to refresh ltex when files are manually modified
+    server_start = true,  -- boolean : Enable the call to ltex. Useful for migration and test
     server_opts = nil,
 }
 
@@ -24,6 +25,9 @@ local function call_ltex(server_opts)
 end
 
 local function first_load()
+    local fs = require("ltex_extra.utils.fs")
+    fs.set_path()
+    fs.init_watcher()
     if M.opts.init_check == true then
         M.reload(M.opts.load_langs)
     end

--- a/lua/ltex_extra/utils/fs.lua
+++ b/lua/ltex_extra/utils/fs.lua
@@ -1,40 +1,91 @@
 local log = require("ltex_extra.utils.log")
-local config_path = package.loaded.ltex_extra.opts.path
 local uv = vim.loop
 
 local M = {}
 
--- Returns path to the directory where ltex files should be located.
-M.path = function()
-    -- Check if the absolute path the user has provided is valid
-    if config_path ~= "" and M.path_exist(config_path) then
-        return config_path .. "/"
-    else
-        -- Assume relative path so append to the cwd
-        return vim.fs.normalize(uv.cwd() .. "/" .. config_path) .. "/"
+-- Sets the path where ltex files should be located.
+M.set_path = function()
+    log.trace("Setting ltex files path")
+    local path = package.loaded.ltex_extra.opts.path
+    path = vim.fs.normalize(path)
+    if M.check_dir(path) then
+        -- Get the fullpath in case it is relative
+        local realpath = uv.fs_realpath(path)
+        if realpath then
+            M.path = vim.fs.normalize(realpath) .. "/"
+            log.info("Set ltex file path to", M.path)
+            return
+        end
     end
+    log.vimerror("Failed to set path to " .. package.loaded.ltex_extra.opts.path)
+end
+
+-- Initialises the file watcher
+M.init_watcher = function()
+    log.trace("Starting file watcher on directory", M.path)
+    if not M.watcher then
+        -- fs_poll works better than fs_event because it does not trigger when
+        -- appending to existing files and works on both windows and linux
+        -- fs_event also has a tendency to spam events
+        M.watcher = uv.new_fs_poll()
+        M.watcher_skip = 0
+    end
+
+    -- Stop watcher on exit
+    vim.api.nvim_create_autocmd("VimLeavePre", {
+        callback = function()
+            if M.watcher and not M.watcher:is_closing() then
+                M.watcher:stop()
+            end
+        end,
+    })
+
+    -- The file watcher only works if the directory already exists when it's
+    -- started
+    if not M.check_dir(M.path) then
+        return false
+    end
+
+    -- Poll with 5 second interval
+    M.watcher:start(M.path, 5000, vim.schedule_wrap(M.watcher_callback))
+end
+
+-- Called when the file watcher detects a change
+M.watcher_callback = function(err, _, _)
+    log.trace("Detected file watcher change")
+    if err then
+        log.vimerror("File watcher error:", err)
+    end
+    if M.watcher_skip > 0 then
+        M.watcher_skip = M.watcher_skip - 1
+        log.debug("Ignoring file watcher change")
+        return
+    end
+    log.info("Invoking reload from file watcher change")
+    require("ltex_extra").reload()
 end
 
 -- Returns the filename for a type and lang required.
 M.joinPath = function(type, lang)
-    return vim.fs.normalize(M.path() .. table.concat({ "ltex", type, lang, "txt" }, "."))
+    return vim.fs.normalize(M.path .. table.concat({ "ltex", type, lang, "txt" }, "."))
 end
 
 -- Check if path exist. Apply for files and dirs.
+-- Will also return true for relative paths.
 M.path_exist = function(path)
-    log.trace("Checking path ", path)
+    log.trace("Checking path", path)
     return uv.fs_stat(path) ~= nil
 end
 
 -- Make a specified directory and check if created succesfully.
 M.mkdir = function(dirname)
-    log.trace("Making dir ", dirname)
+    log.trace("Making dir", dirname)
     local ok, err = uv.fs_mkdir(dirname, 484)
     if not ok then
-        log.vimwarn("Failed making directory: ", err)
+        log.vimwarn("Failed making directory:", err)
         return false
     else
-        log.info("Directory made succesfully ", dirname)
+        log.info("Directory made successfully", dirname)
         return true
     end
 end
@@ -48,8 +99,8 @@ M.check_dir = function(dirname)
         if M.mkdir(dirname) then
             return true
         end
+        return false
     end
-    ---@diagnostic disable-next-line: need-check-nil
     if stat.type ~= "directory" then
         log.vimwarn(dirname .. " is not a directory")
         return false
@@ -59,7 +110,12 @@ end
 
 -- Write specified content into a file.
 M.writeFile = function(filename, lines)
-    log.trace("Writing ", filename, lines)
+    log.trace("Writing", filename, lines)
+    if not M.path_exist(filename) then
+        -- As this is creating a new file, it will trigger the file watcher
+        -- Increment the skip counter to ensure we don't reload config
+        M.watcher_skip = M.watcher_skip + 1
+    end
     local fd, err = uv.fs_open(filename, "a+", 420)
     if not fd then
         log.vimerror("Failed to open file " .. filename .. ": " .. err)
@@ -71,9 +127,9 @@ end
 
 -- Export ltex data depends on the type and lang especified.
 M.exportFile = function(type, lang, lines)
-    log.trace("Exporting ", type, lang, lines)
+    log.trace("Exporting", type, lang, lines)
     local filename = M.joinPath(type, lang)
-    if M.check_dir(M.path()) then
+    if M.check_dir(M.path) then
         M.writeFile(filename, lines)
     else
         log.vimwarn("Fail export " .. filename)
@@ -102,7 +158,7 @@ end
 
 -- Return the content of a required file
 M.readFile = function(filename)
-    log.trace("Reading ", filename)
+    log.trace("Reading", filename)
     local fd, err = uv.fs_open(filename, "r", 420)
     if not fd then
         log.vimerror("Failed to open file " .. filename .. ": " .. err)
@@ -121,7 +177,7 @@ end
 -- Return the content of a required type and lang.
 -- If the file doesn't exist, return empty table.
 M.loadFile = function(type, lang)
-    log.trace("Loading ", type, lang)
+    log.trace("Loading", type, lang)
     local content = {}
     local filename = M.joinPath(type, lang)
     if M.path_exist(filename) then

--- a/lua/ltex_extra/utils/fs.lua
+++ b/lua/ltex_extra/utils/fs.lua
@@ -7,6 +7,9 @@ local M = {}
 M.set_path = function()
     log.trace("Setting ltex files path")
     local path = package.loaded.ltex_extra.opts.path
+    if path == "" then
+        path = assert(uv.cwd())
+    end
     path = vim.fs.normalize(path)
     if M.check_dir(path) then
         -- Get the fullpath in case it is relative

--- a/lua/ltex_extra/utils/fs.lua
+++ b/lua/ltex_extra/utils/fs.lua
@@ -111,7 +111,7 @@ end
 -- Write specified content into a file.
 M.writeFile = function(filename, lines)
     log.trace("Writing", filename, lines)
-    if not M.path_exist(filename) then
+    if package.loaded.ltex_extra.opts.file_watcher and not M.path_exist(filename) then
         -- As this is creating a new file, it will trigger the file watcher
         -- Increment the skip counter to ensure we don't reload config
         M.watcher_skip = M.watcher_skip + 1


### PR DESCRIPTION
Closes #31

Seems to mostly work well on Windows and Linux apart from one issue I can't work out. As it is, this PR contains a couple potential incompatibilities:

- Leaving the `path` option empty (the root project directory) won't work with the file watcher as it will refresh for all file changes in the working directory. This could be resolved by changing the default path to a relative directory like `.ltex` or maybe by forcefully disabling the file watcher in this scenario?
- Manually setting `path` to a directory that isn't exclusivelty for ltex files will cause the same problem. I've added a `file_watcher` option that is disabled by default along with a warning message in the readme to hopefully prevent any issues with this.

The path for saving ltex files now gets set once in `on_attach`. This prevents stuff from breaking if the user changes their working directory whilst Neovim is open. The downside is that this won't support multiple instances of the ltex lsp, although I don't think this was supported before anyway.

### Known issue
Spellings manually deleted from the dictionary are not reflected by LSP diagnostics.

Steps to reproduce:

1. Enable the file watcher and open a document inside a workspace that contains a dictionary with existing spelling overrides
2. With the document still open, manually delete a spelling entry from the dictionary file
3. Observe that the Neovim diagnostics do not show deleted word now having incorrect spelling

I can see in the logs that ltex is correctly refreshing with the updated dictionary contents so the file watcher seems to be working fine. What's strange is that the issue only occurs for spellings that existed in the dictionary before opening Neovim. If a definition is added whilst Neovim is running (via code actions or manually), it can be manually deleted from the dictionary file and the change is reflected correctly.