### PR TITLE
fix: Correctly differentiate between absolute and relative paths

### DIFF
--- a/lua/ltex_extra/utils/fs.lua
+++ b/lua/ltex_extra/utils/fs.lua
@@ -7,14 +7,14 @@ local M = {}
 
 -- Returns path to the directory where ltex files should be located.
 M.path = function()
-    -- Check if the absolute path the user has provided is valid
-    if config_path ~= "" and M.path_exist(config_path) then
+    -- Check if the path is absolute.
+    if config_path:sub(1,1) == "/" then
         return config_path .. "/"
     end
 
     local root_dir = server_opts and server_opts.root_dir or uv.cwd()
 
-    -- Assume relative path and append to the root dir
+    -- Assume relative path and append to the root dir.
     return vim.fs.normalize(root_dir .. "/" .. config_path) .. "/"
 end
 


### PR DESCRIPTION
Fixes the issue https://github.com/barreiroleo/ltex_extra.nvim/issues/41

Now, the behavior of missing subdirectories is the same as if the relative path were provided:

- If no subdirectory is missing, no directory is created. 
- If only the last subdirectory is missing, it's created.
- If more than the one subdirectories are missing, the error is thrown.

Before this commit, if the relative path would be provided, and the last directory was missing, it would be created. But, when the absolute path would be provided and the last directory was missing, the absolute path would be treated as relative path. So the plugin would concatenate `root_dir` and the absolute path, which would result in one long path, meaning not only the last directory would be missing, but the whole second part of newly created path, and an error would be thrown.