### PR TITLE
Set en-US as default load_langs language

### DIFF
--- a/lua/ltex_extra/init.lua
+++ b/lua/ltex_extra/init.lua
@@ -1,11 +1,11 @@
 local M = {}
 
 M.opts = {
-    init_check = true,   -- boolean : whether to load dictionaries on startup
-    load_langs = {},     -- table <string> : language for witch dictionaries will be loaded
-    log_level = "none",  -- string : "none", "trace", "debug", "info", "warn", "error", "fatal"
-    path = "",           -- string : path to store dictionaries. Project root or current working directory
-    server_start = true, -- boolean : Enable the call to ltex. Usefull for migration and test
+    init_check = true,        -- boolean : whether to load dictionaries on startup
+    load_langs = { "en-US" }, -- table <string> : language for witch dictionaries will be loaded
+    log_level = "none",       -- string : "none", "trace", "debug", "info", "warn", "error", "fatal"
+    path = "",                -- string : path to store dictionaries. Project root or current working directory
+    server_start = true,      -- boolean : Enable the call to ltex. Usefull for migration and test
     server_opts = nil,
 }
 


### PR DESCRIPTION
This PR just sets the default value "en-US" to `load_langs`, as suggested in the README file.

Setting the value solves the issue of not loading the custom dictionary (etc) when `load_lang` hasn't been set, as mentioned in https://github.com/barreiroleo/ltex_extra.nvim/issues/45.

Just spent about an hour debugging why my ltex would ignore my custom dictionary after each restart, so figured I'd just make a quick PR to save others from doing the same :)

## Test plan

- Ran without setting `load_langs` and tracing and saw it pick up the correct default language.
```lua
require("ltex_extra").setup({ log_level = 'trace' })
--[ltex_extra] [TRACE 04:56:31] /Users/christoffer/src/ltex_extra.nvim/lua/ltex_extra/commands-lsp.lua:79: updateConfigFull
--[ltex_extra] [TRACE 04:56:31] /Users/christoffer/src/ltex_extra.nvim/lua/ltex_extra/commands-lsp.lua:82: Loading "en-US"
```

- Ran with a custom load_langs to make sure it's respected
```lua
require("ltex_extra").setup({ log_level = 'trace', load_langs = { "sv-SE" }})
--[ltex_extra] [TRACE 04:59:58] /Users/christoffer/src/ltex_extra.nvim/lua/ltex_extra/commands-lsp.lua:79: updateConfigFull
--[ltex_extra] [TRACE 04:59:58] /Users/christoffer/src/ltex_extra.nvim/lua/ltex_extra/commands-lsp.lua:82: Loading "sv-SE"
```
