### PR TITLE
Fix orthographic errors in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Lua](https://img.shields.io/badge/Lua-blue.svg?style=for-the-badge&logo=lua)](http://www.lua.org)
 ![Work In Progress](https://img.shields.io/badge/Work%20In%20Progress-orange?style=for-the-badge)
 ![Neovim](https://img.shields.io/badge/NeoVim-%2357A143.svg?&style=for-the-badge&logo=neovim&logoColor=white)
+
 <!-- [![Neovim Nightly](https://img.shields.io/badge/Neovim%20Nightly-green.svg?style=for-the-badge&logo=neovim)](https://neovim.io) -->
 </div>
 
@@ -23,8 +24,8 @@ such implementations for Neovim. The current supported methods are:
 [`disableRule`](https://valentjn.github.io/ltex/ltex-ls/server-usage.html#_ltexdisablerules-client),
 [`hideFalsePositive`](https://valentjn.github.io/ltex/ltex-ls/server-usage.html#_ltexaddtodictionary-client).
 
-
 <!--toc:start-->
+
 - [LTeX_extra.nvim](#ltexextranvim)
   - [Features](#features)
     - [Code Actions](#code-actions)
@@ -36,30 +37,33 @@ such implementations for Neovim. The current supported methods are:
     - [Force reload](#force-reload)
     - [Lspsaga:](#lspsaga)
   - [Contributors](#contributors)
-<!--toc:end-->
-
+  <!--toc:end-->
 
 ## Features
+
 > [!WARNING]
 > The following demos may contain orthographic horrors.
 
 ### Code Actions
-**Add *word* to dictionary**, **Hide false positive**, and **Disable rule**
+
+**Add _word_ to dictionary**, **Hide false positive**, and **Disable rule**
 
 https://user-images.githubusercontent.com/48270301/177694689-b6b12b4a-3981-47fe-aa88-567697f797bd.mp4
 
-### Custom export path
+### Custom Export Path
+
 Give you compatibility with official vscode extension, and flexibility to do things like global dictionaries.
 
 https://user-images.githubusercontent.com/48270301/177694714-2f9d7477-26b6-4bf5-a47e-63ce2f82d76a.mp4
 
-### On start load
+### Load on Start
+
 Load ltex files on server start.
 
 https://user-images.githubusercontent.com/48270301/177694724-736159ab-c202-4325-ad23-405c76676b79.mp4
 
-
 ## Installation
+
 🚧 This plugin will be rewritten and as consequence I want to support just one
 method to initialize the plugin. The chosen one probably will be based on the
 LspAttach autocommand. I won't support the server initialization through
@@ -67,59 +71,60 @@ this plugin anymore. It was a bad decision, doesn't provide much value and is
 hard to maintain.
 
 This plugin requires an instance of `ltex_ls` language server available to attach.
-*[`ltex-ls`](https://github.com/valentjn/ltex-ls) is available at [`mason.nvim`](https://github.com/williamboman/mason.nvim).*
+_[`ltex-ls`](https://github.com/valentjn/ltex-ls) is available at [`mason.nvim`](https://github.com/williamboman/mason.nvim)._
 
 Install the plugin with your favorite plugin manager using `{"barreiroleo/ltex-extra.nvim"}`.
-Then add `require("ltex_extra").setup()` to your config in a proper place.
+Then add `require("ltex_extra").setup()` to your config.
 
-We suggest to you two ways:
-- Call the `setup` from `on_attach` function of your server. Example with
-`lspconfig`, minor changes are required for `mason` handler:
-    ```lua
-    require("lspconfig").ltex.setup {
-        capabilities = your_capabilities,
-        on_attach = function(client, bufnr)
-            -- rest of your on_attach process.
-            require("ltex_extra").setup { your_opts }
-        end,
-        settings = {
-            ltex = { your settings }
-        }
-    }
-    ```
-- Use the handler which `ltex_extra` provide to call the server. Example of use with `lazy.nvim`:
+There are two recommended methods:
 
-    ```lua
-    return {
-        "barreiroleo/ltex_extra.nvim",
-        ft = { "markdown", "tex" },
-        dependencies = { "neovim/nvim-lspconfig" },
-        -- yes, you can use the opts field, just I'm showing the setup explicitly
-        config = function()
-            require("ltex_extra").setup {
-                your_ltex_extra_opts,
-                server_opts = {
-                    capabilities = your_capabilities,
-                    on_attach = function(client, bufnr)
-                        -- your on_attach process
-                    end,
-                    settings = {
-                        ltex = { your settings }
-                    }
-                },
-            }
-        end
+1. Call the `setup` from `on_attach` function of your server. Example with
+   `lspconfig`, minor changes are required for `mason` handler:
+   `lua
+require("lspconfig").ltex.setup {
+    capabilities = your_capabilities,
+    on_attach = function(client, bufnr)
+        -- rest of your on_attach process.
+        require("ltex_extra").setup { your_opts }
+    end,
+    settings = {
+        ltex = { your settings }
     }
-    ```
+}
+`
+2. Use the handler which `ltex_extra` provide to call the server. Example of use with `lazy.nvim`:
+
+   ```lua
+   return {
+       "barreiroleo/ltex_extra.nvim",
+       ft = { "markdown", "tex" },
+       dependencies = { "neovim/nvim-lspconfig" },
+       -- yes, you can use the opts field, just I'm showing the setup explicitly
+       config = function()
+           require("ltex_extra").setup {
+               your_ltex_extra_opts,
+               server_opts = {
+                   capabilities = your_capabilities,
+                   on_attach = function(client, bufnr)
+                       -- your on_attach process
+                   end,
+                   settings = {
+                       ltex = { your settings }
+                   }
+               },
+           }
+       end
+   }
+   ```
 
 ## Configuration
 
 Here are the settings available on `ltex_extra`. You don't need explicit define each
 one, just modify what you need.
 
-*Notes: You can pass to set up only the arguments that you are interested in.
-At the moment, if you define stuff in `dictionary`, `disabledRules` and
-`hiddenFalsePositives` in your `ltex` settings, they haven't backup.*
+_Notes: You can pass to `setup` the arguments that you are interested in and omit the rest.
+At the moment, if you have `dictionary`, `disabledRules` and
+`hiddenFalsePositives` defined in your `ltex` settings, they aren't backed up._
 
 ```lua
 require("ltex_extra").setup {
@@ -141,20 +146,22 @@ require("ltex_extra").setup {
 ```
 
 ## FAQ
+
 ### Force reload
-If you experiment some hangs with the server/plugin, you can force a reload of
+
+If you experience hangs with the server/plugin, you can force a reload of
 the LTeX files by running `require("ltex_extra").reload()`
 
 https://user-images.githubusercontent.com/48270301/177694740-bc8bdb4c-0f6b-4f63-98af-54ec23196f27.mp4
 
 ### Lspsaga:
-Some users of lspsaga has reported issues with code actions. I not use lspsaga,
-so PRs are very welcome. Just make sure to test without that plugin enabled as well.
+
+Some users of lspsaga has reported issues with code actions. I don't use lspsaga,
+so PRs are welcome. Just make sure to test without that plugin enabled as well.
 
 https://user-images.githubusercontent.com/39244876/201530888-077e76ad-211c-408f-80dc-89ba59751532.mov
 
-_Thanks to @felipejoribeiro for the screenrecording_
-
+_Thanks to @felipejoribeiro for the screen recording_
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- LTeX: language=en-US -->
 <div align="center">
-<h6>🚧 This plugin will be rewritten, I'll do my best to maintain the specs but expect some changes</h6>
+<h6>🚧 Dev branch will be merged soon. Please take a look at the Deprecations notes in dev branch. </h6>
 
 # LTeX_extra.nvim
 


### PR DESCRIPTION
I have fixed some orthographic errors in the readme file, as well as improving the flow of and clarified the sentences.