### PR TITLE
fix: Master branch fix for vim.lsp.get_active_clients depreciation

### DIFF
--- a/lua/ltex_extra/commands-lsp.lua
+++ b/lua/ltex_extra/commands-lsp.lua
@@ -49,7 +49,8 @@ local M = {}
 
 function M.catch_ltex()
     log.trace("catch_ltex")
-    local buf_clients = vim.lsp.get_active_clients({
+    local client_getter = vim.lsp.get_clients and vim.lsp.get_clients or vim.lsp.get_active_clients
+    local buf_clients = client_getter({
         bufnr = vim.api.nvim_get_current_buf(),
         name = "ltex",
     })


### PR DESCRIPTION
This PR is a fix for the `vim.lsp.get_active_clients()` depreciation in Neovim 0.10 to remove a related warning message.

(Similar to the fix in [dev branch](https://github.com/barreiroleo/ltex_extra.nvim/commit/1515eeb6c0fbd56b259b701ea0c8c5b63304657d), but this could stop the warning message from affecting master branch users until dev branch is merged)