### PR TITLE
feat: deprecation notice on on_attach() based setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ these methods that are off the LSP specification. The current supported methods 
 - [LTeX_extra.nvim](#ltexextranvim)
   - [Features](#features)
   - [Installation and setup](#installation-and-setup)
-  - [Deprecated options notes](#deprecated-options-notes)
+  - [Deprecated options notes](#deprecations)
   - [FAQ](#faq)
     - [Lspsaga:](#lspsaga)
   - [Contributors](#contributors)
@@ -75,7 +75,7 @@ manager*:
         ---@type "none" | "fatal" | "error" | "warn" | "info" | "debug" | "trace"
         log_level = "none",
         ---@type string File's path to load.
-        -- The setup will normalice it running vim.fs.normalize(path).
+        -- The setup will normalize it by running vim.fs.normalize(path).
         -- e.g. subfolder in project root or cwd: ".ltex"
         -- e.g. cross project settings:  vim.fn.expand("~") .. "/.local/share/ltex"
         path = ".ltex",

--- a/lua/ltex_extra/init.lua
+++ b/lua/ltex_extra/init.lua
@@ -158,6 +158,14 @@ function LtexExtra:CallLtexServer(opts)
 end
 
 function ltex_extra_api.setup(opts)
+    if vim.g.loaded_ltex_extra then
+        vim.notify("[LtexExtra] on_attach() based setup will be deprecated soon. Please consider updating your settings."
+            .. " Raise an issue at github.com/barreiroleo/ltex_extra.nvim if you have any concerns.",
+            vim.log.levels.WARN)
+        return false
+    end
+    vim.g.loaded_ltex_extra = true
+
     opts = vim.tbl_deep_extend("force", def_opts, opts or {})
     opts.path = vim.fs.normalize(opts.path)
     -- Initialize the logger


### PR DESCRIPTION
As mentioned in #60, I added an automatic deprecation warnings that is triggered if `setup()` is called for the 2nd time, since that implies the user is still using the `on_attach()` based setup. Also fixed the broken anchor link on README that caught my eye. 

Note: despite having `stylua.toml` on the repo, the code doesn't seem to have formatting applied. I was unsure of what to do and left it untouched.