### PR TITLE
Fix race condition by deferring update until LSP attaches.

### DIFF
--- a/lua/ltex_extra/commands-lsp.lua
+++ b/lua/ltex_extra/commands-lsp.lua
@@ -57,7 +57,6 @@ function M.catch_ltex()
     return buf_clients[1]
 end
 
--- Modified updateConfig: if no client is attached, wait for LspAttach
 function M.updateConfig(configtype, lang)
     log.trace("updateConfig")
     local client = M.catch_ltex()

--- a/lua/ltex_extra/commands-lsp.lua
+++ b/lua/ltex_extra/commands-lsp.lua
@@ -79,7 +79,7 @@ function M.updateConfig(configtype, lang)
             once = true,
             callback = function(args)
                 local attached_client = vim.lsp.get_client_by_id(args.data.client_id)
-                if attached_client and attached_client.name == "ltex" then
+                if attached_client and attached_client.name == "ltex_plus" then
                     M.updateConfig(configtype, lang)
                 end
             end,


### PR DESCRIPTION
Fix: Improve startup robustness: Defer LTeX configuration updates until LspAttach event.

During Neovim startup, the LTeX LSP client may initialize asynchronously. This change defers the `updateConfig` function to be triggered by the `LspAttach` event, ensuring the client is attached before attempting to send configuration changes and preventing potential errors.