### PR TITLE
fix: use `client:notify` instead of deprecated `client.notify` in `commands-lsp.lua`

### DIFF
--- a/lua/ltex_extra/commands-lsp.lua
+++ b/lua/ltex_extra/commands-lsp.lua
@@ -26,7 +26,7 @@ local function update_dictionary(client, lang)
     local settings = get_settings(client)
     settings.ltex.dictionary[lang] = loadFile(types.dict, lang)
     log.debug(vim.inspect(settings.ltex.dictionary))
-    return client.notify("workspace/didChangeConfiguration", settings)
+    return client:notify("workspace/didChangeConfiguration", settings)
 end
 
 local function update_disabledRules(client, lang)
@@ -34,7 +34,7 @@ local function update_disabledRules(client, lang)
     local settings = get_settings(client)
     settings.ltex.disabledRules[lang] = loadFile(types.dRules, lang)
     log.debug(vim.inspect(settings.ltex.disabledRules))
-    return client.notify("workspace/didChangeConfiguration", settings)
+    return client:notify("workspace/didChangeConfiguration", settings)
 end
 
 local function update_hiddenFalsePositive(client, lang)
@@ -42,7 +42,7 @@ local function update_hiddenFalsePositive(client, lang)
     local settings = get_settings(client)
     settings.ltex.hiddenFalsePositives[lang] = loadFile(types.hRules, lang)
     log.debug(vim.inspect(settings.ltex.hiddenFalsePositives))
-    return client.notify("workspace/didChangeConfiguration", settings)
+    return client:notify("workspace/didChangeConfiguration", settings)
 end
 
 local M = {}


### PR DESCRIPTION
Problem
- Neovim prints a deprecation warning: "client.notify is deprecated..."
- Code used `client.notify(...)` which should use method-call `client:notify(...)`.

Change
- Replaced occurrences in `lua/ltex_extra/commands-lsp.lua` to use `client:notify("workspace/didChangeConfiguration", settings)`.

Rationale
- Avoids deprecation warnings and future breakage with Neovim 0.13+.

Testing
- This is a small syntactic/API-call change. No functional logic changed. Recommend maintainers run their CI; locally you can run the test suite or a headless Neovim test (see commands below).